### PR TITLE
Return boolean true for handle method if command is successful

### DIFF
--- a/src/Handler/CreatingTacticianHandler.php
+++ b/src/Handler/CreatingTacticianHandler.php
@@ -50,6 +50,7 @@ final class CreatingTacticianHandler implements MessageHandler
             ));
         }
 
-        return $bus->handle(new QueuedCommand($message));
+        $bus->handle(new QueuedCommand($message));
+        return true;
     }
 }

--- a/src/Handler/TacticianHandler.php
+++ b/src/Handler/TacticianHandler.php
@@ -39,6 +39,7 @@ final class TacticianHandler implements MessageHandler
      */
     public function handle(Message $message, array $options=[])
     {
-        return $this->tactician->handle(new QueuedCommand($message));
+        $this->tactician->handle(new QueuedCommand($message));
+        return true;
     }
 }


### PR DESCRIPTION
Commands without return values were always treated as failed.

The PMG\Queue\MessageHandler::handle() method should return a boolean but the implementation is returning the value returned from the command bus handle method.

This causes any commands without a return value to be treated as a failed command.
