### PR TITLE
Upgrade for pmg/queue 5.x

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 /coverage
 /phpunit.xml
 /composer.lock
+.phpunit.result.cache
 
 *.pyc
 *.swp

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,12 @@
 language: php
 
 php:
-  - 7.0
-  - 7.1
+  - '7.3'
+  - '7.4'
 
 notifications:
-  email:
-    recipients:
-      - tech@pmg.com
-    on_success: change
-    on_failure: always
+  email: false
 
-install: composer install --prefer-source
+install: composer install
 
 script: make test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,11 +3,20 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## 5.0.0
+
+Skipping versions to bring all of our pmg/queue libraries to a same major
+version number.
+
+### Changed
+
+- `pmg/queue` 5.X is now required.
+
 ## 2.0.0
 
 ### Changed
 
-- [BC BREAK] The library no requires tactician ~1.0
+- [BC BREAK] The library now requires tactician ~1.0
 
 ### Fixed
 

--- a/composer.json
+++ b/composer.json
@@ -8,9 +8,8 @@
         "league/tactician": "~1.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "~6.2"
+        "phpunit/phpunit": "^8.0"
     },
-    "minimum-stability": "dev",
     "autoload": {
         "psr-4": {
             "PMG\\Queue\\": "src/"

--- a/composer.json
+++ b/composer.json
@@ -4,10 +4,11 @@
     "keywords": ["commandbus", "queue"],
     "license": "Apache-2.0",
     "require": {
-        "pmg/queue": "~4.0",
-        "league/tactician": "~1.0"
+        "pmg/queue": "^5.0",
+        "league/tactician": "^1.0"
     },
     "require-dev": {
+        "pmg/queue": "^5.0@beta",
         "phpunit/phpunit": "^8.0"
     },
     "autoload": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -8,7 +8,6 @@
          convertWarningsToExceptions="true"
          processIsolation="false"
          stopOnFailure="false"
-         syntaxCheck="false"
          bootstrap="test/bootstrap.php">
 
     <testsuites>

--- a/src/Handler/CreatingTacticianHandler.php
+++ b/src/Handler/CreatingTacticianHandler.php
@@ -40,7 +40,7 @@ final class CreatingTacticianHandler implements MessageHandler
     /**
      * {@inheritdoc}
      */
-    public function handle(Message $message, array $options=[]) : PromiseInterface
+    public function handle(object $message, array $options=[]) : PromiseInterface
     {
         $promise = new Promise(function () use (&$promise, $message, $options) {
             $bus = call_user_func($this->factory, $options);

--- a/src/Handler/TacticianHandler.php
+++ b/src/Handler/TacticianHandler.php
@@ -39,7 +39,7 @@ final class TacticianHandler implements MessageHandler
     /**
      * {@inheritdoc}
      */
-    public function handle(Message $message, array $options=[]) : PromiseInterface
+    public function handle(object $message, array $options=[]) : PromiseInterface
     {
         $promise = new Promise(function () use (&$promise, $message) {
             $result = $this->tactician->handle(new QueuedCommand($message));

--- a/src/Tactician/QueuedCommand.php
+++ b/src/Tactician/QueuedCommand.php
@@ -12,8 +12,6 @@
 
 namespace PMG\Queue\Tactician;
 
-use PMG\Queue\Message;
-
 /**
  * Used to wrapped incoming commands. This exists so commands don't go into an
  * endless loop of queueing where the consumer dequeues the a command that
@@ -27,21 +25,19 @@ final class QueuedCommand
     /**
      * The wrapped command.
      *
-     * @var Message
+     * @var object
      */
     private $message;
 
-    public function __construct(Message $message)
+    public function __construct(object $message)
     {
         $this->message = $message;
     }
 
     /**
      * Pull the message out of the queued command.
-     *
-     * @return   Message
      */
-    public function unwrap()
+    public function unwrap() : object
     {
         return $this->message;
     }

--- a/test/Fixtures/IsMessage.php
+++ b/test/Fixtures/IsMessage.php
@@ -16,7 +16,7 @@ use PMG\Queue\Message;
 
 class IsMessage implements Message
 {
-    public function getName()
+    public function getName() : string
     {
         return __CLASS__;
     }

--- a/test/Handler/TacticianHandlerTest.php
+++ b/test/Handler/TacticianHandlerTest.php
@@ -52,7 +52,7 @@ class TacticianHandlerTest extends \PMG\Queue\TacticianTestCase
         $this->assertSame($expected, $result);
     }
 
-    protected function setUp()
+    protected function setUp() : void
     {
         $this->commandHandler = new DummyHandler();
         $this->bus = new CommandBus([

--- a/test/Tactician/QueueingMiddlewareTest.php
+++ b/test/Tactician/QueueingMiddlewareTest.php
@@ -56,7 +56,7 @@ class QueueingMiddlewareTest extends \PMG\Queue\TacticianTestCase
         $this->assertSame($command, $this->handler->command);
     }
 
-    protected function setUp()
+    protected function setUp() : void
     {
         $this->handler = new DummyHandler();
         $this->producer = $this->createMock(Producer::class);


### PR DESCRIPTION
THought the core no longer requires `PMG\Queue\Message`, this library still does to make `QueueingMiddleware` work.