### PR TITLE
Alli 11919 add return type

### DIFF
--- a/src/Tactician/QueueingMiddleware.php
+++ b/src/Tactician/QueueingMiddleware.php
@@ -36,7 +36,7 @@ final class QueueingMiddleware implements Middleware
 
     /**
      * {@inheritdoc}
-     * @return mixed
+     * @return mixed|void
      */
     public function execute($command, callable $next)
     {

--- a/src/Tactician/QueueingMiddleware.php
+++ b/src/Tactician/QueueingMiddleware.php
@@ -36,6 +36,7 @@ final class QueueingMiddleware implements Middleware
 
     /**
      * {@inheritdoc}
+     * @return mixed
      */
     public function execute($command, callable $next)
     {


### PR DESCRIPTION
Included annotation return types to remove indirect deprecations found in alli-products-backend.